### PR TITLE
fix: improve help messages for hp, lslog, nurl, and mkfile

### DIFF
--- a/src/bin/hp
+++ b/src/bin/hp
@@ -27,10 +27,25 @@ Usage: hp <command>
 
 Displays help information for OLS commands.
 
+Available commands:
+    gx           Git clone wrapper (clone repos by user/repo shorthand)
+    hp           Show help for any OLS command (this command)
+    lslog        View OLS activity logs
+    mkfile       Create files or directories
+    nurl         Download files from URLs (wget wrapper)
+    ols          Start the OLS interactive shell
+    olsp         OLS plugin manager
+    open         Open files with the default application
+    targz        Create or extract .tar.gz archives
+    uedit        Edit files with your preferred editor
+    ulog         Log messages to the OLS log file
+    xsystem     Execute system commands with logging
+
 Examples:
     hp gx        show help for gx
     hp lslog     show help for lslog
     hp mkfile    show help for mkfile
+    hp targz     show help for targz
 EOF
 }
 

--- a/src/bin/lslog
+++ b/src/bin/lslog
@@ -10,15 +10,23 @@ LOG_FILE="$HOME/OLS/logs.log"
 # ===== Help =====
 show_help() {
 	cat <<'EOF'
+lslog - View OLS activity logs
+
 usage:
-    lslog
+    lslog              Display all log entries
+    lslog --help       Show this help message
+
 description:
-	This is a small utility 
-	for viewing logs.
+    Prints the contents of the OLS log file (~/.OLS/logs.log).
+    Each log entry includes a timestamp, component name, and message.
+    Pipe the output to filter, sort, or search log entries.
+
 examples:
-	lslog
-	lslog | sort | uniq
-	lslog | grep EE
+    lslog                    show all logs
+    lslog | grep EE          show only errors
+    lslog | grep gx          show only gx command logs
+    lslog | tail -20         show the last 20 log entries
+    lslog | sort | uniq      show unique log entries
 EOF
 }
 

--- a/src/bin/mkfile
+++ b/src/bin/mkfile
@@ -22,18 +22,28 @@ die() {
 # ===== Help =====
 show_help() {
     cat <<'EOF'
+mkfile - Create files and directories
+
 usage:
-    mkfile <-f|-d> <filename>
+    mkfile -f <filename> [<filename>...]    Create one or more files
+    mkfile -d <dirname> [<dirname>...]      Create one or more directories
+    mkfile --help                           Show this help message
+
 description:
-    This is a small utility 
-    for creating files and directories.
+    A utility for quickly creating files (touch) or directories (mkdir -p).
+    Files must not already exist (prevents accidental overwrites).
+    Directories are created with -p (parent dirs created as needed).
+
 options:
-    -f         create file 
-    -d         create directory
-    --help     show help
+    -f         Create empty file(s) (fails if file already exists)
+    -d         Create directory/directories (creates parents if needed)
+    --help     Show this help message
+
 examples:
-    mkfile -f text.txt
-    mkfile -d directory/
+    mkfile -f text.txt                 create a single file
+    mkfile -f a.txt b.txt c.txt        create multiple files
+    mkfile -d myproject                create a directory
+    mkfile -d src/components/ui        create nested directories
 EOF
 }
 

--- a/src/bin/nurl
+++ b/src/bin/nurl
@@ -22,14 +22,24 @@ die() {
 # ===== Helpers =====
 show_help() {
     cat <<'EOF'
-nurl - Net URL Load
+nurl - Net URL Load (download files from the web)
 
 usage:
-	nurl <URL>
+    nurl <URL>         Download a file from the given URL
+    nurl --help        Show this help message
+
+description:
+    Downloads files from HTTP/HTTPS URLs using wget.
+    The file is saved to the current directory.
+    You can also pipe the output to other commands.
+
+requires:
+    wget
+
 examples:
-    nurl https://example.com/file.zip
-    nurl https://example.com/ > index.html
-    nurl https://example.com/ | less
+    nurl https://example.com/file.zip         download a file
+    nurl https://example.com/ > index.html    save page as HTML
+    nurl https://example.com/ | less          view page content
 EOF
 }
 


### PR DESCRIPTION
## Summary
Improved help messages across 4 OLS commands to be clearer and more informative:

### hp (help command)
- Added a complete list of all available OLS commands with one-line descriptions
- Users can now see all commands at a glance without guessing

### lslog
- Added command name in header
- Expanded description to explain the log format and file location
- Added practical examples (grep for errors, tail for recent entries)

### nurl
- Added description explaining what the command does
- Added `requires:` section noting wget dependency
- Better organized example section

### mkfile
- Rewritten description to be specific (touch/mkdir -p behavior)
- Documented multiple file support and nested directory creation
- Added more practical examples

Closes #2

## Test plan
- [x] All 4 commands display improved help with `--help` flag
- [x] No functional changes to command behavior

